### PR TITLE
fix port number typo.

### DIFF
--- a/articles/active-directory/msi-tutorial-linux-vm-access-arm.md
+++ b/articles/active-directory/msi-tutorial-linux-vm-access-arm.md
@@ -89,7 +89,7 @@ To complete these steps, you will need an SSH client. If you are using Windows, 
     The CURL request for the access token is below.  
     
     ```bash
-    curl http://localhost:50432/oauth2/token --data "resource=https://management.azure.com/" -H Metadata:true   
+    curl http://localhost:50342/oauth2/token --data "resource=https://management.azure.com/" -H Metadata:true   
     ```
     
     > [!NOTE]


### PR DESCRIPTION
MSI Agent default port number is 50342. not 50432.

You can check the port with the following command.
```
$ sudo lsof -i | grep msi
msi-exten  1758         root    6u  IPv4  21079      0t0  TCP localhost:50342 (LISTEN)
```
or  logs in
/var/log/azure/Microsoft.ManagedIdentity.ManagedIdentityExtensionForLinux/